### PR TITLE
Added delete helpers that support multiple delete commands.

### DIFF
--- a/Sources/MongoKitten/CollectionHelpers/Collection+Delete.swift
+++ b/Sources/MongoKitten/CollectionHelpers/Collection+Delete.swift
@@ -31,4 +31,23 @@ extension MongoCollection {
     public func deleteAll<Q: MongoKittenQuery>(where filter: Q) -> EventLoopFuture<DeleteReply> {
         return self.deleteAll(where: filter.makeDocument())
     }
+    
+    /// Performs a delete operation with the given delete statements
+    /// - Parameter removals: A collection of one or more delete statements to perform.
+    public func deleteAll(_ removals: [DeleteCommand.Removal]) -> EventLoopFuture<DeleteReply> {
+        return pool.next(for: .writable).flatMap { connection in
+            return connection.executeCodable(
+                DeleteCommand(removals, fromCollection: self.name),
+                namespace: self.database.commandNamespace,
+                in: self.transaction,
+                sessionId: connection.implicitSessionId
+            )
+        }.decodeReply(DeleteReply.self)._mongoHop(to: hoppedEventLoop)
+    }
+    
+    /// Performs a delete operation with the given delete statement.
+    /// - Parameter removal: A delete statement to perform.
+    public func deleteOne(_ removal: DeleteCommand.Removal) -> EventLoopFuture<DeleteReply> {
+        return self.deleteAll([removal])
+    }
 }


### PR DESCRIPTION
## Description
This PR adds 2 new helpers on the `MongoCollection`  (`deleteMany(...)` and `deleteOne(...)`) type that allows specifying multiple `Delete` operations to perform.

```swift
let d1 = DeleteCommand.Removal(where: ["_id": 1])
let d2 = DeleteCommand.Removal(where: ["_id": 2])
let d3 = DeleteCommand.Removal(where: ["_id": 3])
...
collection.deleteMany([d1, d2, d3])
```

```swift
let d1 = DeleteCommand.Removal(where: ["_id": 1])
...
collection.deleteOne(d1)
```

## Motivation and Context
This gives more flexibility to take advantage of the `DeleteCommand`

## How Has This Been Tested?
It hasn't but it shouldn't have any side effects.
## Checklist:
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.