### PR TITLE
Jo broader connection support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ var package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
 
         // 📚
-        .package(url: "https://github.com/openkitten/NioDNS.git", .revision("master")),
+        .package(url: "https://github.com/openkitten/NioDNS.git", .revision("32ceb697aa6e142166e2d85d591fcd644e78625f")),
         
         
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
 
         // 📚
-        .package(url: "https://github.com/openkitten/NioDNS.git", .revision("39f456b139a0dec7112f7bc8ceee5c5617cc9980")),
+        .package(url: "https://github.com/openkitten/NioDNS.git", from: "2.0.0"),
         
         // 🔑
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0")

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "MongoKitten",
     platforms: [
-        .macOS(.v10_14)
+        .macOS(.v10_14),
+        .ios(.v12),
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
 
         // 📚
-        .package(url: "https://github.com/openkitten/NioDNS.git", .revision("66bbe9d2ee2bb977d6788924dcbcab72150a45aa")),
+        .package(url: "https://github.com/openkitten/NioDNS.git", .revision("634087cbdd5b2dddbd0fba58423e88c2efca295a")),
         
         
         // 🔑

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
 
         // 📚
-        .package(url: "https://github.com/openkitten/NioDNS.git", .revision("32ceb697aa6e142166e2d85d591fcd644e78625f")),
+        .package(url: "https://github.com/openkitten/NioDNS.git", .revision("66bbe9d2ee2bb977d6788924dcbcab72150a45aa")),
         
         
         // 🔑

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,7 +7,7 @@ let package = Package(
     name: "MongoKitten",
     platforms: [
         .macOS(.v10_14),
-        .ios(.v12),
+        .iOS(.v12),
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -38,8 +38,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
 
         // 📚
-        .package(url: "https://github.com/openkitten/NioDNS.git", .revision("634087cbdd5b2dddbd0fba58423e88c2efca295a")),
-        
+        .package(url: "https://github.com/openkitten/NioDNS.git", .revision("39f456b139a0dec7112f7bc8ceee5c5617cc9980")),
         
         // 🔑
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0")

--- a/Sources/MongoClient/Cluster.swift
+++ b/Sources/MongoClient/Cluster.swift
@@ -180,7 +180,7 @@ public final class MongoCluster: MongoConnectionPool {
         let client: EventLoopFuture<DNSClient>
         
         do {
-            #if canImport(NIOTransportServices) && os(iOS)
+            #if canImport(NIOTransportServices)
                 if let dnsServer = settings.dnsServer {
                     client = try DNSClient.connectTS(on: loop, config: [SocketAddress(ipAddress: dnsServer, port: 53)])
                 } else {

--- a/Sources/MongoClient/Cluster.swift
+++ b/Sources/MongoClient/Cluster.swift
@@ -3,7 +3,7 @@ import Logging
 import DNSClient
 import MongoCore
 
-#if canImport(NIOTransportServices) && os(iOS)
+#if canImport(NIOTransportServices)
 import NIOTransportServices
 
 public typealias _MongoPlatformEventLoopGroup = NIOTSEventLoopGroup

--- a/Sources/MongoClient/Connection.swift
+++ b/Sources/MongoClient/Connection.swift
@@ -5,7 +5,7 @@ import NIO
 import Logging
 import Metrics
 
-#if canImport(NIOTransportServices) && os(iOS)
+#if canImport(NIOTransportServices)
 import Network
 import NIOTransportServices
 #else
@@ -98,7 +98,7 @@ public final class MongoConnection {
     ) -> EventLoopFuture<MongoConnection> {
         let context = MongoClientContext(logger: logger)
 
-        #if canImport(NIOTransportServices) && os(iOS)
+        #if canImport(NIOTransportServices)
         var bootstrap = NIOTSConnectionBootstrap(group: eventLoop)
 
         if settings.useSSL {

--- a/Sources/MongoClient/SASL.swift
+++ b/Sources/MongoClient/SASL.swift
@@ -14,7 +14,7 @@ fileprivate enum ProgressState {
     case verify(signature: [UInt8])
 }
 
-struct CachedCredentials: Codable {
+public struct CachedCredentials: Codable {
     enum CachedCredentialsVersion: Int, Codable {
         case first = 1
     }
@@ -55,12 +55,12 @@ public final class MongoCredentialsCache {
         }
     }
     
-    public static func saveCache() throws -> Document {
-        return try BSONEncoder().encode(CachedCredentials(credentials: Self.default._cache))
+    public static func saveCache() throws -> CachedCredentials {
+        CachedCredentials(credentials: Self.default._cache)
     }
     
-    public static func loadCache(from document: Document) throws {
-        Self.default._cache = try BSONDecoder().decode(CachedCredentials.self, from: document).credentials
+    public static func loadCache(from cache: CachedCredentials) throws {
+        Self.default._cache = cache.credentials
     }
     
     public static func clearCache() {

--- a/Sources/MongoKitten/MongoDatabase.swift
+++ b/Sources/MongoKitten/MongoDatabase.swift
@@ -3,7 +3,7 @@ import Logging
 import Foundation
 import NIO
 
-#if canImport(NIOTransportServices) && os(iOS)
+#if canImport(NIOTransportServices)
 import NIOTransportServices
 #endif
 
@@ -57,7 +57,7 @@ public class MongoDatabase {
     /// - throws: Can throw for a variety of reasons, including an invalid connection string, failure to connect to the MongoDB database, etcetera.
     /// - returns: A connected database instance
     public static func synchronousConnect(_ uri: String) throws -> MongoDatabase {
-        #if canImport(NIOTransportServices) && os(iOS)
+        #if canImport(NIOTransportServices)
         let group = NIOTSEventLoopGroup(loopCount: 1, defaultQoS: .default)
         #else
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -74,7 +74,7 @@ public class MongoDatabase {
     /// - throws: Can throw for a variety of reasons, including an invalid connection string, failure to connect to the MongoDB database, etcetera.
     /// - returns: A connected database instance
     public static func synchronousConnect(settings: ConnectionSettings) throws -> MongoDatabase {
-        #if canImport(NIOTransportServices) && os(iOS)
+        #if canImport(NIOTransportServices)
         let group = NIOTSEventLoopGroup(loopCount: 1, defaultQoS: .default)
         #else
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)

--- a/Sources/MongoKitten/MongoDatabase.swift
+++ b/Sources/MongoKitten/MongoDatabase.swift
@@ -3,10 +3,6 @@ import Logging
 import Foundation
 import NIO
 
-#if canImport(NIOTransportServices)
-import NIOTransportServices
-#endif
-
 /// A reference to a MongoDB database, over a `Connection`.
 ///
 /// Databases hold collections of documents.
@@ -57,13 +53,7 @@ public class MongoDatabase {
     /// - throws: Can throw for a variety of reasons, including an invalid connection string, failure to connect to the MongoDB database, etcetera.
     /// - returns: A connected database instance
     public static func synchronousConnect(_ uri: String) throws -> MongoDatabase {
-        #if canImport(NIOTransportServices)
-        let group = NIOTSEventLoopGroup(loopCount: 1, defaultQoS: .default)
-        #else
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        #endif
-
-        return try self.connect(uri, on: group).wait()
+        return try self.connect(uri, on: MultiThreadedEventLoopGroup(numberOfThreads: 1)).wait()
     }
 
     /// A helper method that uses the normal `connect` method with the given settings and awaits it. It creates an event loop group for you.
@@ -74,13 +64,7 @@ public class MongoDatabase {
     /// - throws: Can throw for a variety of reasons, including an invalid connection string, failure to connect to the MongoDB database, etcetera.
     /// - returns: A connected database instance
     public static func synchronousConnect(settings: ConnectionSettings) throws -> MongoDatabase {
-        #if canImport(NIOTransportServices)
-        let group = NIOTSEventLoopGroup(loopCount: 1, defaultQoS: .default)
-        #else
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        #endif
-
-        return try self.connect(settings: settings, on: group).wait()
+        return try self.connect(settings: settings, on: MultiThreadedEventLoopGroup(numberOfThreads: 1)).wait()
     }
 
     /// Connect to the database at the given `uri`

--- a/Tests/MongoKittenTests/MobileTests.swift
+++ b/Tests/MongoKittenTests/MobileTests.swift
@@ -14,7 +14,7 @@ class CRUDTests : XCTestCase {
     var db: MongoCluster!
 
     override func setUp() {
-        db = try! MongoCluster.connect(on: loop, settings: settings)
+        db = try! MongoCluster.connect(on: loop, settings: settings).wait()
     }
     
     func testListDatabases() throws {


### PR DESCRIPTION
When used with NIOTS, this PR can be used to introduce Network.framework support. This PR also allows other custom channels to be used, for example for use with a proxy.

In addition, this PR introduces access to the cache used by MongoKitten to enable quicker connections.

**TODO:**

- [ ] Implement a form of `buildConnection` in the MongoCluster
- [ ] Rename Credentials to CachedMongoCredentials