### PR TITLE
Stale Reference: Basic support for CosmosDB

### DIFF
--- a/Sources/MongoClient/Channel+Connection.swift
+++ b/Sources/MongoClient/Channel+Connection.swift
@@ -20,12 +20,15 @@ internal struct ClientConnectionParser: ByteToMessageDecoder {
         do {
             let result = try parser.parse(from: &buffer)
 
-            if let reply = parser.takeReply(), !context.handleReply(reply) {
+            guard let reply = parser.takeReply(), context.handleReply(reply) else {
                 print("Reply received from MongoDB, but no request was waiting for the result.")
+                return result
             }
 
+            print(result, reply)
             return result
         } catch {
+            print("error", error)
             self.context.cancelQueries(error)
             self.context.didError = true
             throw error
@@ -33,12 +36,14 @@ internal struct ClientConnectionParser: ByteToMessageDecoder {
     }
 
     mutating func decodeLast(context ctx: ChannelHandlerContext, buffer: inout ByteBuffer, seenEOF: Bool) throws -> DecodingState {
+        print(buffer.readableBytes, "last")
         return try decode(context: ctx, buffer: &buffer)
     }
 
     // TODO: this does not belong here but on the next handler
     func errorCaught(context ctx: ChannelHandlerContext, error: Error) {
         // So that it can take the remaining queries and re-try them
+        print("error", error)
         ctx.close(promise: nil)
     }
 }

--- a/Sources/MongoClient/Connection+Execute.swift
+++ b/Sources/MongoClient/Connection+Execute.swift
@@ -29,14 +29,14 @@ extension MongoConnection {
     ) -> EventLoopFuture<MongoServerReply> {
         let result: EventLoopFuture<MongoServerReply>
         
-        if
-            let serverHandshake = serverHandshake,
-            serverHandshake.maxWireVersion.supportsOpMessage
-        {
-            result = executeOpMessage(command, namespace: namespace, in: transaction, sessionId: sessionId)
-        } else {
+//        if
+//            let serverHandshake = serverHandshake,
+//            serverHandshake.maxWireVersion.supportsOpMessage
+//        {
+//            result = executeOpMessage(command, namespace: namespace, in: transaction, sessionId: sessionId)
+//        } else {
             result = executeOpQuery(command, namespace: namespace, in: transaction, sessionId: sessionId)
-        }
+//        }
 
         if let queryTimer = queryTimer {
             let date = Date()
@@ -127,6 +127,7 @@ extension MongoConnection {
                 command.appendValue(true, forKey: "startTransaction")
             }
         }
+        
         return self.executeMessage(
             OpMessage(
                 body: command,

--- a/Sources/MongoClient/Helpers.swift
+++ b/Sources/MongoClient/Helpers.swift
@@ -49,12 +49,12 @@ extension MongoServerReply {
 }
 
 internal extension Decodable {
-    init(reply: MongoServerReply, assertOk: Bool = true) throws {
+    init(reply: MongoServerReply, assertOk: Bool = true, decoder: BSONDecoder = BSONDecoder()) throws {
         if assertOk {
             try reply.assertOK()
         }
         
-        self = try BSONDecoder().decode(Self.self, from: reply.getDocument())
+        self = try decoder.decode(Self.self, from: reply.getDocument())
     }
 }
 

--- a/Sources/MongoKitten/MongoDatabase.swift
+++ b/Sources/MongoKitten/MongoDatabase.swift
@@ -288,8 +288,8 @@ internal extension MongoConnectionPoolRequest {
 }
 
 internal extension Decodable {
-    init(reply: MongoServerReply) throws {
-        self = try BSONDecoder().decode(Self.self, from: reply.getDocument())
+    init(reply: MongoServerReply, decoder: BSONDecoder = BSONDecoder()) throws {
+        self = try decoder.decode(Self.self, from: reply.getDocument())
     }
 }
 


### PR DESCRIPTION
I hope nobody wants this in practice. This is a hell to support, and frankly, even if I implement the support I don't want to test against this target. More info: https://github.com/vapor/fluent-mongo-driver/issues/42