### PR TITLE
Added write concern support for insert APIs.

### DIFF
--- a/Sources/Meow/AsyncAwait.swift
+++ b/Sources/Meow/AsyncAwait.swift
@@ -98,13 +98,13 @@ extension MutableModel {
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension MeowCollection.Async where M: MutableModel {
     @discardableResult
-    public func insert(_ instance: M) async throws -> InsertReply {
-        return try await nio.insert(instance).get()
+    public func insert(_ instance: M, writeConcern: WriteConcern? = nil) async throws -> InsertReply {
+        return try await nio.insert(instance, writeConcern: writeConcern).get()
     }
     
     @discardableResult
-    public func insertMany(_ instances: [M]) async throws -> InsertReply {
-        return try await nio.insertMany(instances).get()
+    public func insertMany(_ instances: [M], writeConcern: WriteConcern? = nil) async throws -> InsertReply {
+        return try await nio.insertMany(instances, writeConcern: writeConcern).get()
     }
     
     @discardableResult

--- a/Sources/Meow/AsyncAwait.swift
+++ b/Sources/Meow/AsyncAwait.swift
@@ -113,23 +113,23 @@ extension MeowCollection.Async where M: MutableModel {
     }
     
     @discardableResult
-    public func deleteOne(where filter: Document) async throws -> DeleteReply {
-        return try await nio.deleteOne(where: filter).get()
+    public func deleteOne(where filter: Document, writeConcern: WriteConcern? = nil) async throws -> DeleteReply {
+        return try await nio.deleteOne(where: filter, writeConcern: writeConcern).get()
     }
     
     @discardableResult
-    public func deleteOne<Q: MongoKittenQuery>(where filter: Q) async throws -> DeleteReply {
-        return try await nio.deleteOne(where: filter).get()
+    public func deleteOne<Q: MongoKittenQuery>(where filter: Q, writeConcern: WriteConcern? = nil) async throws -> DeleteReply {
+        return try await nio.deleteOne(where: filter, writeConcern: writeConcern).get()
     }
     
     @discardableResult
-    public func deleteAll(where filter: Document) async throws -> DeleteReply {
-        return try await nio.deleteAll(where: filter).get()
+    public func deleteAll(where filter: Document, writeConcern: WriteConcern? = nil) async throws -> DeleteReply {
+        return try await nio.deleteAll(where: filter, writeConcern: writeConcern).get()
     }
     
     @discardableResult
-    public func deleteAll<Q: MongoKittenQuery>(where filter: Q) async throws -> DeleteReply {
-        return try await nio.deleteAll(where: filter).get()
+    public func deleteAll<Q: MongoKittenQuery>(where filter: Q, writeConcern: WriteConcern? = nil) async throws -> DeleteReply {
+        return try await nio.deleteAll(where: filter, writeConcern: writeConcern).get()
     }
     
     //    public func saveChanges(_ changes: PartialChange<M>) -> EventLoopFuture<UpdateReply> {

--- a/Sources/Meow/MeowCollection.swift
+++ b/Sources/Meow/MeowCollection.swift
@@ -62,20 +62,20 @@ extension MeowCollection where M: MutableModel {
         return raw.upsertEncoded(instance, where: "_id" == instance._id)
     }
     
-    public func deleteOne(where filter: Document) -> EventLoopFuture<DeleteReply> {
-        return raw.deleteOne(where: filter)
+    public func deleteOne(where filter: Document, writeConcern: WriteConcern? = nil) -> EventLoopFuture<DeleteReply> {
+        return raw.deleteOne(where: filter, writeConcern: writeConcern)
     }
     
-    public func deleteOne<Q: MongoKittenQuery>(where filter: Q) -> EventLoopFuture<DeleteReply> {
-        return self.deleteOne(where: filter.makeDocument())
+    public func deleteOne<Q: MongoKittenQuery>(where filter: Q, writeConcern: WriteConcern? = nil) -> EventLoopFuture<DeleteReply> {
+        return self.deleteOne(where: filter.makeDocument(), writeConcern: writeConcern)
     }
     
-    public func deleteAll(where filter: Document) -> EventLoopFuture<DeleteReply> {
-        return raw.deleteAll(where: filter)
+    public func deleteAll(where filter: Document, writeConcern: WriteConcern? = nil) -> EventLoopFuture<DeleteReply> {
+        return raw.deleteAll(where: filter, writeConcern: writeConcern)
     }
     
-    public func deleteAll<Q: MongoKittenQuery>(where filter: Q) -> EventLoopFuture<DeleteReply> {
-        return self.deleteAll(where: filter.makeDocument())
+    public func deleteAll<Q: MongoKittenQuery>(where filter: Q, writeConcern: WriteConcern? = nil) -> EventLoopFuture<DeleteReply> {
+        return self.deleteAll(where: filter.makeDocument(), writeConcern: writeConcern)
     }
     
     //    public func saveChanges(_ changes: PartialChange<M>) -> EventLoopFuture<UpdateReply> {

--- a/Sources/Meow/MeowCollection.swift
+++ b/Sources/Meow/MeowCollection.swift
@@ -50,12 +50,12 @@ extension MeowCollection where M: ReadableModel {
 }
 
 extension MeowCollection where M: MutableModel {
-    public func insert(_ instance: M) -> EventLoopFuture<InsertReply> {
-        return raw.insertEncoded(instance)
+    public func insert(_ instance: M, writeConcern: WriteConcern? = nil) -> EventLoopFuture<InsertReply> {
+        return raw.insertEncoded(instance, writeConcern: writeConcern)
     }
     
-    public func insertMany(_ instances: [M]) -> EventLoopFuture<InsertReply> {
-        return raw.insertManyEncoded(instances)
+    public func insertMany(_ instances: [M], writeConcern: WriteConcern? = nil) -> EventLoopFuture<InsertReply> {
+        return raw.insertManyEncoded(instances, writeConcern: writeConcern)
     }
     
     public func upsert(_ instance: M) -> EventLoopFuture<UpdateReply> {

--- a/Sources/MongoKitten/AsyncAwait.swift
+++ b/Sources/MongoKitten/AsyncAwait.swift
@@ -145,23 +145,23 @@ extension MongoCollection {
         }
         
         @discardableResult
-        public func insert(_ document: Document) async throws -> InsertReply {
-            try await nio.insert(document).get()
+        public func insert(_ document: Document, writeConcern: WriteConcern? = nil) async throws -> InsertReply {
+            try await nio.insert(document, writeConcern: writeConcern).get()
         }
         
         @discardableResult
-        public func insertMany(_ documents: [Document]) async throws -> InsertReply {
-            try await nio.insertMany(documents).get()
+        public func insertMany(_ documents: [Document], writeConcern: WriteConcern? = nil) async throws -> InsertReply {
+            try await nio.insertMany(documents, writeConcern: writeConcern).get()
         }
         
         @discardableResult
-        public func insertEncoded<E: Encodable>(_ document: E) async throws -> InsertReply {
-            try await nio.insertEncoded(document).get()
+        public func insertEncoded<E: Encodable>(_ document: E, writeConcern: WriteConcern? = nil) async throws -> InsertReply {
+            try await nio.insertEncoded(document, writeConcern: writeConcern).get()
         }
         
         @discardableResult
-        public func insertManyEncoded<E: Encodable>(_ documents: [E]) async throws -> InsertReply {
-            try await nio.insertManyEncoded(documents).get()
+        public func insertManyEncoded<E: Encodable>(_ documents: [E], writeConcern: WriteConcern? = nil) async throws -> InsertReply {
+            try await nio.insertManyEncoded(documents, writeConcern: writeConcern).get()
         }
         
         @discardableResult

--- a/Sources/MongoKitten/AsyncAwait.swift
+++ b/Sources/MongoKitten/AsyncAwait.swift
@@ -109,23 +109,23 @@ extension MongoCollection {
         }
         
         @discardableResult
-        public func deleteOne(where query: Document) async throws -> DeleteReply {
-            try await nio.deleteOne(where: query).get()
+        public func deleteOne(where query: Document, writeConcern: WriteConcern? = nil) async throws -> DeleteReply {
+            try await nio.deleteOne(where: query, writeConcern: writeConcern).get()
         }
         
         @discardableResult
-        public func deleteOne<Query: MongoKittenQuery>(where query: Query) async throws -> DeleteReply {
-            try await nio.deleteOne(where: query).get()
+        public func deleteOne<Query: MongoKittenQuery>(where query: Query, writeConcern: WriteConcern? = nil) async throws -> DeleteReply {
+            try await nio.deleteOne(where: query, writeConcern: writeConcern).get()
         }
         
         @discardableResult
-        public func deleteAll(where query: Document) async throws -> DeleteReply {
-            try await nio.deleteAll(where: query).get()
+        public func deleteAll(where query: Document, writeConcern: WriteConcern? = nil) async throws -> DeleteReply {
+            try await nio.deleteAll(where: query, writeConcern: writeConcern).get()
         }
         
         @discardableResult
-        public func deleteAll<Query: MongoKittenQuery>(where query: Query) async throws -> DeleteReply {
-            try await nio.deleteAll(where: query).get()
+        public func deleteAll<Query: MongoKittenQuery>(where query: Query, writeConcern: WriteConcern? = nil) async throws -> DeleteReply {
+            try await nio.deleteAll(where: query, writeConcern: writeConcern).get()
         }
         
         public func find(_ query: Document = [:]) -> FindQueryBuilder {

--- a/Tests/MongoKittenTests/CRUDTests.swift
+++ b/Tests/MongoKittenTests/CRUDTests.swift
@@ -479,7 +479,7 @@ class CrudTests : XCTestCase {
     }
     
     func testDistinctValues () throws {
-        let originalAccounts = try testBulkCreateDummyAccounts()
+        _ = try testBulkCreateDummyAccounts()
         let schema: MongoCollection = mongo[DummyAccount.collectionName]
         var results = try schema.distinctValues(forKey: "name").wait()
         XCTAssertEqual(results.count, 300)
@@ -520,11 +520,11 @@ class CrudTests : XCTestCase {
         XCTAssertEqual(result[1].name, "nameIndex")
     }
     
-    func testBuildIndexes() async throws {
-        mongo.async["test"].buildIndexes {
-            
-        }
-    }
+//    func testBuildIndexes() async throws {
+//        mongo.async["test"].buildIndexes {
+//
+//        }
+//    }
 
     // TODO ON ICE: Foreach future
     // TODO ON ICE: Change stream


### PR DESCRIPTION
## Description
This PR adds support for specifying a `write concern`  when performing insert commands.

## Motivation and Context
This makes it easier to add a write concern using the collection convenience APIs vs constructing an `InsertCommand` manually and manually executing it.