### PR TITLE
Added warning for aggregation stages compatibility issues

### DIFF
--- a/Sources/MongoKitten/Aggregate.swift
+++ b/Sources/MongoKitten/Aggregate.swift
@@ -107,6 +107,13 @@ public struct AggregateBuilderPipeline: QueryCursor {
         let command = makeCommand()
         
         return getConnection().flatMap { connection in
+            
+            let minimalVersionRequired = stages.compactMap { $0.minimalVersionRequired }.min()
+
+            if let actualVersion = connection.wireVersion, let minimalVersion = minimalVersionRequired, actualVersion < minimalVersion {
+                print("WARNING: Aggregation might fail since one or more aggregation stages require a higher MongoDB version than currently provided by the connection.")
+            }
+            
             return connection.executeCodable(
                 command,
                 namespace: self.collection.database.commandNamespace,

--- a/Sources/MongoKitten/Aggregate.swift
+++ b/Sources/MongoKitten/Aggregate.swift
@@ -111,7 +111,7 @@ public struct AggregateBuilderPipeline: QueryCursor {
             let minimalVersionRequired = stages.compactMap { $0.minimalVersionRequired }.min()
 
             if let actualVersion = connection.wireVersion, let minimalVersion = minimalVersionRequired, actualVersion < minimalVersion {
-                print("WARNING: Aggregation might fail since one or more aggregation stages require a higher MongoDB version than currently provided by the connection.")
+                connection.logger.warning("Aggregation might fail since one or more aggregation stages require a higher MongoDB version than provided by the current connection.")
             }
             
             return connection.executeCodable(


### PR DESCRIPTION
These changes allow MongoKitten to output a warning whenever a MongoDB connection that doesn't match the minimal required version of used aggregation stages.