### PR TITLE
Require version 7.0.28 of BSON to avoid Swift 5.5 build errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0" ..< "3.0.0"),        
         
         // 💾
-        .package(url: "https://github.com/OpenKitten/BSON.git", from: "7.0.0"),
+        .package(url: "https://github.com/OpenKitten/BSON.git", from: "7.0.28"),
         
         // 🚀
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),


### PR DESCRIPTION
## Description
[BSON 7.0.0 has build issues in Swift 5.5 that are resolved in 7.0.28](https://github.com/orlandos-nl/BSON/issues/69).  I bumped the minimum version of BSON so that SPM will not potentially resolve package version that will cause MongoKitten to fail to build on newer versions of Swift.

## Motivation and Context
I was following [this raywenderlich.com tutorial](https://www.raywenderlich.com/10521463-server-side-swift-with-mongodb-getting-started) and the starter project failed to build.  This is a tough onboarding experience for people who are learning.  After I did some research and discovered the source of the issue (a default protocol conformance marked unavailable in Swift 5.5) and that the issue had been fixed already in BSON, I figured I would try to make the onboarding experience easier for the next developer by preventing pre 7.0.28 version of BSON from being used.

## How Has This Been Tested?
I tested that this builds in the current version of Xcode.  

I was not able to test that it works on Swift 5.0 because when I downloaded the 5.0 toolchain and tried to build the project, I got error messages that the am64 version of the standard library could not be found for my OS version.  I assume this is because I am on an M1 Mac and that Swift toolchain is older and simply does not work on this machine.  I could be wrong.  I have only limited experience working with alternate toolchains.

I also tried downloading an older version of Xcode to test Swift 5.0, but macOS Monterey only supports Xcode 15 so I didn't have much success there.  I don't think there's any reason it _wouldn't_ work with older Swift versions.  At this point, given the effort required to get an old Swift toolchain running in Linux or something to test this, I figured I'd put the PR up and see if there's even any concern about it not working on 5.0 or if anyone has an easier way to test it.

## Checklist:
- [ ] If applicable, I have updated the documentation accordingly. (Not applicable)
- [ ] If applicable, I have added tests to cover my changes. (Not applicable)