### PR TITLE
implement workaround for compiler crash #60380

### DIFF
--- a/Sources/MongoClient/Connection.swift
+++ b/Sources/MongoClient/Connection.swift
@@ -202,7 +202,9 @@ public final actor MongoConnection: @unchecked Sendable {
         self.lastHeartbeat = MongoHandshakeResult(sentAt: sent, handshake: result)
         return result
     }
-    
+    // `@inline(never)` needed due to the llvm coroutine splitting issue 
+    // `https://github.com/apple/swift/issues/60380`.
+    @inline(never)
     public func authenticate(
         clientDetails: MongoClientDetails?,
         using credentials: ConnectionSettings.Authentication,

--- a/Sources/MongoClient/MongoSingleConnectionPool.swift
+++ b/Sources/MongoClient/MongoSingleConnectionPool.swift
@@ -33,7 +33,7 @@ public final actor MongoSingleConnectionPool: MongoConnectionPool {
             return connection
         }
         
-        let connection = try await self.buildConnection()
+        let connection = try await buildConnection()
         try await connection.authenticate(
             clientDetails: nil,
             using: self.credentials,

--- a/Sources/MongoClient/MongoSingleConnectionPool.swift
+++ b/Sources/MongoClient/MongoSingleConnectionPool.swift
@@ -34,22 +34,11 @@ public final actor MongoSingleConnectionPool: MongoConnectionPool {
         }
         
         let connection = try await self.buildConnection()
-        // we must inline ``MongoConnection.authenticate(clientDetails:using:to:)`` 
-        // due to the llvm coroutine splitting issue `https://github.com/apple/swift/issues/60380`. 
-        // 
-        // this could also be accomplished by adding `@inline(never)` to 
-        // ``MongoConnection.authenticate(clientDetails:using:to:)``, but this 
-        // preserves the runtime behavior more closely.
-        let handshake = try await connection.doHandshake(
+        try await connection.authenticate(
             clientDetails: nil,
-            credentials: self.credentials,
-            authenticationDatabase: self.authenticationSource
+            using: self.credentials,
+            to: self.authenticationSource
         )
-        
-        await connection.context.setServerHandshake(to: handshake)
-        try await connection.authenticate(to: self.authenticationSource, 
-            serverHandshake: handshake, 
-            with: self.credentials)
         
         self.connection = connection
         


### PR DESCRIPTION
we must manually inline [`MongoConnection.authenticate(clientDetails:using:to:)`](https://swiftinit.org/reference/mongokitten/mongoclient/mongoconnection.authenticate%28clientdetails:using:to:%29) into [`MongoSingleConnectionPool.next(for:)`](https://swiftinit.org/reference/mongokitten/mongoclient/mongosingleconnectionpool.next%28for:%29) due to the llvm coroutine splitting issue https://github.com/apple/swift/issues/60380. 
        
this could also be accomplished by adding `@inline(never)` to `MongoConnection.authenticate(clientDetails:using:to:)`, but this preserves the runtime behavior more closely.