### PR TITLE
Adds test for transaction.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,7 +18,7 @@ jobs:
         
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install Swift
+      - if: matrix.os == 'ubuntu-20.04'
         uses: slashmo/install-swift@v0.1.0
         with:
           version: ${{ matrix.swiftVersion }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -34,15 +34,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Install docker
-        run: |
-            brew install docker docker-machine docker-compose
-            mkdir -p ~/.docker/cli-plugins
-            ln -sfn /usr/local/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
-            
-            brew install --cask virtualbox
-            docker-machine create --driver virtualbox default
-            eval "$(docker-machine env default)"
-            docker ps
+        uses: docker-practice/actions-setup-docker@master
             
       - name: Check out  
         uses: actions/checkout@v3

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -24,7 +24,8 @@ jobs:
           version: ${{ matrix.swiftVersion }}
           
       - uses: docker-practice/actions-setup-docker@master
-        if: matrix.os == 'macos-latest'
+      
+      - if: matrix.os == 'macos-latest'
         run: set -x
           
       - name: Check out

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,24 +14,30 @@ jobs:
       fail-fast: false
       matrix:
         swiftVersion: [5.6]
-        os: [ubuntu-20.04, macos-latest]
         
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
-      - if: matrix.os == 'ubuntu-20.04'
         uses: slashmo/install-swift@v0.1.0
         with:
           version: ${{ matrix.swiftVersion }}
-          
-      - uses: docker-practice/actions-setup-docker@master
-      
-      - if: matrix.os == 'macos-latest'
-        run: set -x
-          
       - name: Check out
         uses: actions/checkout@v3
         
       - name: Setup Mongo
         run: docker-compose up -d
+        
       - name: Run tests
         run: swift test
+        
+  test-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        mongodb-version: ['4,2', '4.4', '5.0']
+    runs-on: macos-latest
+    steps:
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.7.0
+        with:
+          mongodb-version: ${{ matrix.mongodb-version }}
+          mongodb-replica-set: mongo-rs

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -39,6 +39,11 @@ jobs:
             mkdir -p ~/.docker/cli-plugins
             ln -sfn /usr/local/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
             
+            brew install --cask virtualbox
+            docker-machine create --driver virtualbox default
+            eval "$(docker-machine env default)"
+            docker ps
+            
       - name: Check out  
         uses: actions/checkout@v3
         

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,12 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner:
-          - swift:5.6-focal
-          - swiftlang/swift:nightly-main-focal
-    container: ${{ matrix.runner }}
-    runs-on: ubuntu-latest
+        swiftVersion: [5.6]
+        os: [ubuntu-20.04, macos-latest]
+        
+    runs-on: ${{ matrix.os }}
     steps:
+      - name: Install Swift
+        uses: slashmo/install-swift@v0.1.0
+        with:
+          version: ${{ matrix.swiftVersion }}
       - name: Check out
         uses: actions/checkout@v3
       - name: Setup Mongo

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -23,10 +23,9 @@ jobs:
         with:
           version: ${{ matrix.swiftVersion }}
           
-      - name: Install docker
-        uses: docker-practice/actions-setup-docker@master
-        if: matrix.os == 'macos-latest'
-        run: set -x
+      - if: matrix.os == 'macos-latest'
+      - uses: docker-practice/actions-setup-docker@master
+      - run: set -x
           
       - name: Check out
         uses: actions/checkout@v3

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         swiftVersion: [5.6]
-        os: [ubuntu-20.04]
+        os: [ubuntu-20.04, macos-latest]
         
     runs-on: ${{ matrix.os }}
     steps:
@@ -22,8 +22,15 @@ jobs:
         uses: slashmo/install-swift@v0.1.0
         with:
           version: ${{ matrix.swiftVersion }}
+          
+      - name: Install docker
+        uses: docker-practice/actions-setup-docker@master
+        if: matrix.os == 'macos-latest'
+        run: set -x
+          
       - name: Check out
         uses: actions/checkout@v3
+        
       - name: Setup Mongo
         run: docker-compose up -d
       - name: Run tests

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         swiftVersion: [5.6]
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04]
         
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         swiftVersion: [5.6]
+        mongodb-version: ['4.2', '4.4', '5.0']
     steps:
      - name: Check out  
        uses: actions/checkout@v3
@@ -24,8 +25,11 @@ jobs:
        with:
           version: ${{ matrix.swiftVersion }}
         
-     - name: Start Mongo
-       run: docker-compose up -d
+     - name: Start MongoDB
+       uses: supercharge/mongodb-github-action@1.7.0
+       with:
+         mongodb-version: ${{ matrix.mongodb-version }}
+         mongodb-replica-set: test-rs
         
      - name: Run tests
        run: swift test

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -23,9 +23,9 @@ jobs:
         with:
           version: ${{ matrix.swiftVersion }}
           
-      - if: matrix.os == 'macos-latest'
       - uses: docker-practice/actions-setup-docker@master
-      - run: set -x
+        if: matrix.os == 'macos-latest'
+        run: set -x
           
       - name: Check out
         uses: actions/checkout@v3

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,17 +16,19 @@ jobs:
       matrix:
         swiftVersion: [5.6]
     steps:
-        uses: slashmo/install-swift@v0.1.0
-        with:
+     - name: Check out  
+       uses: actions/checkout@v3
+        
+     - name: Install Swift
+       uses: slashmo/install-swift@v0.1.0
+       with:
           version: ${{ matrix.swiftVersion }}
-      - name: Check out
-        uses: actions/checkout@v3
         
-      - name: Setup Mongo
-        run: docker-compose up -d
+     - name: Start Mongo
+       run: docker-compose up -d
         
-      - name: Run tests
-        run: swift test
+     - name: Run tests
+       run: swift test
         
   macos:
     runs-on: macos-latest
@@ -35,8 +37,14 @@ jobs:
       matrix:
         mongodb-version: ['4,2', '4.4', '5.0']
     steps:
+      - name: Check out  
+        uses: actions/checkout@v3
+        
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.7.0
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
           mongodb-replica-set: mongo-rs
+          
+      - name: Run tests
+        run: swift test

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -10,12 +10,11 @@ on:
 
 jobs:
   test-linux:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         swiftVersion: [5.6]
-        
-    runs-on: ubuntu-latest
     steps:
         uses: slashmo/install-swift@v0.1.0
         with:
@@ -30,11 +29,11 @@ jobs:
         run: swift test
         
   test-macos:
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
         mongodb-version: ['4,2', '4.4', '5.0']
-    runs-on: macos-latest
     steps:
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.7.0

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -32,23 +32,18 @@ jobs:
         
   macos:
     runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        mongodb-version: ['4.2', '4.4', '5.0']
     steps:
       - name: Install docker
         run: |
             brew install docker docker-machine docker-compose
+            mkdir -p ~/.docker/cli-plugins
+            ln -sfn /usr/local/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
             
       - name: Check out  
         uses: actions/checkout@v3
         
-      - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.7.0
-        with:
-          mongodb-version: ${{ matrix.mongodb-version }}
-          mongodb-replica-set: mongo-rs
+      - name: Start Mongo
+        run: docker-compose up -d
           
       - name: Run tests
         run: swift test

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,7 +9,7 @@ on:
       - master/7.0
 
 jobs:
-  test-linux:
+  linux:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -28,7 +28,7 @@ jobs:
       - name: Run tests
         run: swift test
         
-  test-macos:
+  macos:
     runs-on: macos-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,23 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dbimage:
-          - mongo
         runner:
           - swift:5.6-focal
           - swiftlang/swift:nightly-main-focal
     container: ${{ matrix.runner }}
     runs-on: ubuntu-latest
-    services:
-      mongo-a:
-        image: ${{ matrix.dbimage }}
-      mongo-b:
-        image: ${{ matrix.dbimage }}
     steps:
       - name: Check out
         uses: actions/checkout@v3
+      - name: Setup Mongo
+        run: docker-compose up -d
       - name: Run tests
         run: swift test
-        env:
-          MONGO_HOSTNAME_A: mongo-a
-          MONGO_HOSTNAME_B: mongo-b

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -35,8 +35,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mongodb-version: ['4,2', '4.4', '5.0']
+        mongodb-version: ['4.2', '4.4', '5.0']
     steps:
+      - name: Install docker
+        run: |
+            brew install docker docker-machine docker-compose
+            
       - name: Check out  
         uses: actions/checkout@v3
         

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -31,7 +31,7 @@ jobs:
        run: swift test
         
   macos:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Install docker
         uses: docker-practice/actions-setup-docker@master

--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,9 @@ let package = Package(
         // 📈
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0" ..< "3.0.0"),
         
+        // ✅
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
+        
         // 💾
         .package(url: "https://github.com/orlandos-nl/BSON.git", from: "8.0.0"),
         //        .package(name: "BSON", path: "../BSON"),
@@ -57,6 +60,7 @@ let package = Package(
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Metrics", package: "swift-metrics"),
+                .product(name: "Atomics", package: "swift-atomics"),
             ]),
         .target(
             name: "MongoKittenCore",

--- a/Sources/MongoClient/Cluster.swift
+++ b/Sources/MongoClient/Cluster.swift
@@ -94,7 +94,7 @@ public final class MongoCluster: MongoConnectionPool, @unchecked Sendable {
     public var slaveOk = false {
         didSet {
             for connection in pool {
-                connection.connection.slaveOk.store(self.slaveOk)
+                connection.connection.slaveOk.store(self.slaveOk, ordering: .relaxed)
             }
         }
     }
@@ -294,7 +294,7 @@ public final class MongoCluster: MongoConnectionPool, @unchecked Sendable {
                 resolver: self.dns,
                 sessionManager: sessionManager
             )
-            connection.slaveOk.store(slaveOk)
+            connection.slaveOk.store(slaveOk, ordering: .relaxed)
 
             /// Ensures we default to the cluster's lowest version
             if let connectionHandshake = await connection.serverHandshake {

--- a/Sources/MongoCore/Sessions.swift
+++ b/Sources/MongoCore/Sessions.swift
@@ -82,7 +82,7 @@ public final class MongoClientSession: @unchecked Sendable {
 internal final class MongoServerSession: @unchecked Sendable {
     internal let sessionId: SessionIdentifier
     internal let lastUse: Date
-    private let transaction = ManagedAtomic<Int>(0)
+    private let transaction = ManagedAtomic<Int>(1)
 
     func nextTransactionNumber() -> Int {
         transaction.loadThenWrappingIncrement(ordering: .relaxed)

--- a/Tests/MongoKittenTests/TransactionTests.swift
+++ b/Tests/MongoKittenTests/TransactionTests.swift
@@ -20,11 +20,8 @@ class TransactionTests: XCTestCase {
     
     override func setUp() async throws {
         try await super.setUp()
-        let mongoSettings = try ConnectionSettings("mongodb://localhost:27017/transaction-test")
+        let mongoSettings = try ConnectionSettings("mongodb://\(ProcessInfo.processInfo.environment["MONGO_HOSTNAME_A"] ?? "localhost")/mongokitten-test")
         mongo = try await MongoDatabase.connect(to: mongoSettings)
-    }
-    
-    override func tearDown() async throws {
         try await mongo.drop()
     }
     

--- a/Tests/MongoKittenTests/TransactionTests.swift
+++ b/Tests/MongoKittenTests/TransactionTests.swift
@@ -22,6 +22,10 @@ class TransactionTests: XCTestCase {
         try await super.setUp()
         let mongoSettings = try ConnectionSettings("mongodb://\(ProcessInfo.processInfo.environment["MONGO_HOSTNAME_A"] ?? "localhost")/mongokitten-test")
         mongo = try await MongoDatabase.connect(to: mongoSettings)
+    }
+    
+    override func tearDown() async throws {
+        try await super.tearDown()
         try await mongo.drop()
     }
     

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,48 @@
+version: "3"
+
+services:
+  mongo-1:
+    image: mongo:5.0
+    ports:
+      - "27017:27017"
+    container_name: mongo-1
+    hostname: mongo-1
+    networks: 
+      - mongo_cluster
+    command: mongod --replSet rs0
+
+  mongo-2:
+    image: mongo:5.0
+    ports:
+      - "27018:27017"
+    container_name: mongo-2
+    hostname: mongo-2
+    networks: 
+      - mongo_cluster
+    command: mongod --replSet rs0
+    depends_on:
+      - mongo-1
+
+  mongo-3:
+    image: mongo:5.0
+    ports:
+      - "27019:27017"
+    container_name: mongo-3
+    hostname: mongo-3
+    networks: 
+      - mongo_cluster
+    command: mongod --replSet rs0
+    depends_on:
+      - mongo-2  
+
+  mongosetup:
+    image: mongo:5.0
+    networks:
+    - mongo_cluster
+    volumes:
+    - ./scripts:/scripts
+    command: bash -c "chmod +x /scripts/setup.sh && /scripts/setup.sh"
+
+networks: 
+  mongo_cluster:
+    driver: bridge

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+sleep 5
+mongo --host mongo-1:27017 <<EOF
+   var cfg = {
+        "_id": "rs0",
+        "version": 1,
+        "members": [
+            {
+                "_id": 0,
+                "host": "mongo-1:27017",
+                "priority": 2
+            },
+            {
+                "_id": 1,
+                "host": "mongo-2:27017",
+                "priority": 1
+            },
+            {
+                "_id": 2,
+                "host": "mongo-3:27017",
+                "priority": 0,
+                "arbiterOnly": true
+            }
+        ]
+    };
+    rs.initiate(cfg, { force: true });
+    rs.reconfig(cfg, { force: true });
+    rs.status();
+EOF


### PR DESCRIPTION
Adds tests around transactions

## Description
There's 2 tests, 1 for testing a transaction while inserting data into 2 separate collections.
and the second test is doing the same while still on the same connection.

## Extra Context
This is happening on MongoDB V5

## Motivation and Context
Have been seeing crashes when running back to back transactions and this adds tests around that area. But in adding the tests, this test case breaks because the connection pool can't seem to determine the max wire version.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.