### PR TITLE
Uses port from SRVRecord

### DIFF
--- a/Sources/MongoClient/Cluster.swift
+++ b/Sources/MongoClient/Cluster.swift
@@ -332,7 +332,7 @@ public final class MongoCluster: MongoConnectionPool, @unchecked Sendable {
     private func resolveSRV(_ host: ConnectionSettings.Host, on client: DNSClient) async throws -> [ConnectionSettings.Host] {
         let prefix = "_mongodb._tcp."
         return try await client.getSRVRecords(from: prefix + host.hostname).get().map { record in
-            return ConnectionSettings.Host(hostname: record.resource.domainName.string, port: host.port)
+            return ConnectionSettings.Host(hostname: record.resource.domainName.string, port: Int(record.resource.port))
         }
     }
     


### PR DESCRIPTION
## Description
Uses port specified in an `SRVRecord` instead of overwriting the port from initial `ConnectionSettings.Host.port` value.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When `mongodb+srv//` scheme is used to connect to a database it uses default port number `27017`. Hosts resolved from the service might use arbitrary port numbers. Using default port to connect to hosts leads to connection error.
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I successfully connected to database via `mongodb+srv//` scheme that resolved hosts requiring specific port number.

 ![Screenshot 2023-10-18 at 15 55 42](https://github.com/orlandos-nl/MongoKitten/assets/2279666/117e9d08-b879-4ff7-8c0f-c52a51e75080)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.