### PR TITLE
replace the `exact` version requirement for DNSClient with a `from` requirement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.43.0"),
         
         // 📚
-        .package(url: "https://github.com/orlandos-nl/DNSClient.git", exact: "2.2.1"),
+        .package(url: "https://github.com/orlandos-nl/DNSClient.git", from: "2.2.1"),
         
         // 🔑
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),


### PR DESCRIPTION
replaces the `exact` version requirement for DNSClient with a `from` requirement, as described in #331 .