### PR TITLE
Mark MeowDatabase as Sendable

### DIFF
--- a/Sources/Meow/Database.swift
+++ b/Sources/Meow/Database.swift
@@ -12,7 +12,7 @@ import NIO
 ///     let mongodb: MongoDatabase = mongoCluster["superapp"]
 ///     let meow = MeowDatabase(mongodb)
 ///     let users: MeowCollection<User> = meow[User.self]
-public class MeowDatabase {
+public class MeowDatabase: @unchecked Sendable {
     public let raw: MongoDatabase
     
     public init(_ database: MongoDatabase) {


### PR DESCRIPTION
`MeowDatabase` is not marked as sendable, potentially resulting in warnings with complete concurrency checking.

## Description
Added `@unchecked Sendable` annotation, because it is modeled as a non-final class. Otherwise it should be perfectly fine.