### PR TITLE
Support aggregate `Group`, fix header doc typo

### DIFF
--- a/Sources/MongoKitten/AggregateStage.swift
+++ b/Sources/MongoKitten/AggregateStage.swift
@@ -41,6 +41,17 @@ public struct AddFields: AggregateBuilderStage {
 
 /// A $group stage in an aggregation pipeline, used to group documents
 /// - SeeAlso: https://docs.mongodb.com/manual/reference/operator/aggregation/group/
+public struct Group: AggregateBuilderStage {
+    public internal(set) var stage: Document
+    public internal(set) var minimalVersionRequired: WireVersion? = nil
+    
+    public init(_ document: Document) {
+        self.stage = ["$group": document]
+    }
+}
+
+/// A $project stage in an aggregation pipeline, used to project documents
+/// - SeeAlso: https://docs.mongodb.com/manual/reference/operator/aggregation/project/
 public struct Project: AggregateBuilderStage {
     public internal(set) var stage: Document
     public internal(set) var minimalVersionRequired: WireVersion?


### PR DESCRIPTION
## Description
Fix the header doc typo of `Project` stage, add simple `Group` stage implementation.

## Motivation and Context
- Using `Group` in Aggregate builder
- Fix confuse header doc

## How Has This Been Tested?
Used it to query a real db.

## Checklist:
- [x] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.