### PR TITLE
Upgrade DNSClient from 2.2.1 to 2.4.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.43.0"),
         
         // 📚
-        .package(url: "https://github.com/orlandos-nl/DNSClient.git", from: "2.2.1"),
+        .package(url: "https://github.com/orlandos-nl/DNSClient.git", from: "2.4.2"),
         
         // 🔑
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -41,7 +41,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.43.0"),
 
         // 📚
-        .package(url: "https://github.com/orlandos-nl/DNSClient.git", from: "2.2.1"),
+        .package(url: "https://github.com/orlandos-nl/DNSClient.git", from: "2.4.2"),
 
         // 🔑
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -41,7 +41,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.43.0"),
 
         // 📚
-        .package(url: "https://github.com/orlandos-nl/DNSClient.git", from: "2.2.1"),
+        .package(url: "https://github.com/orlandos-nl/DNSClient.git", from: "2.4.2"),
 
         // 🔑
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),


### PR DESCRIPTION
## Description
This PR updates the DNSClient dependency from version 2.2.1 to 2.4.2 to resolve Sendable protocol conformance requirements in Cluster.swift.

## Motivation and Context
The current version of DNSClient (2.2.1) lacks Sendable protocol conformance, causing compilation errors in `Cluster.swift`. 
-  #350

## How Has This Been Tested?
- Verified successful compilation with Swift 5.9+

## Checklist:
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.