### PR TITLE
Add Sendable Conformance to Field and Reference Types

### DIFF
--- a/Sources/Meow/KeyPathModel/KeyPathModels.swift
+++ b/Sources/Meow/KeyPathModel/KeyPathModels.swift
@@ -316,7 +316,7 @@ extension QueryableField: _QueryableFieldRepresentable where Value: Codable {
 
 /// The `@Field` property wrapper is used on all stored properties of a ``Model`` to allow key path based queries.
 @propertyWrapper
-public struct Field<C: Codable>: Codable, _QueryableFieldRepresentable {
+public struct Field<C: Codable>: Codable, _QueryableFieldRepresentable, Sendable {
     public typealias Value = C
     public let key: String?
     private var _wrappedValue: C?

--- a/Sources/Meow/KeyPathModel/KeyPathModels.swift
+++ b/Sources/Meow/KeyPathModel/KeyPathModels.swift
@@ -316,7 +316,7 @@ extension QueryableField: _QueryableFieldRepresentable where Value: Codable {
 
 /// The `@Field` property wrapper is used on all stored properties of a ``Model`` to allow key path based queries.
 @propertyWrapper
-public struct Field<C: Codable>: Codable, _QueryableFieldRepresentable, Sendable {
+public struct Field<C: Codable>: Codable, _QueryableFieldRepresentable {
     public typealias Value = C
     public let key: String?
     private var _wrappedValue: C?
@@ -360,6 +360,9 @@ public struct Field<C: Codable>: Codable, _QueryableFieldRepresentable, Sendable
         try container.encode(_wrappedValue!)
     }
 }
+
+// Add conditional Sendable conformance
+extension Field: Sendable where C: Sendable {}
 
 extension Field: Equatable where C: Equatable {
     public static func ==(lhs: Self, rhs: Self) -> Bool {

--- a/Sources/Meow/Reference.swift
+++ b/Sources/Meow/Reference.swift
@@ -13,7 +13,7 @@ import NIO
 ///         let post: Post = try await postRef.resolve(in: req.meow)
 ///         return post
 ///     }
-public struct Reference<M: ReadableModel>: Resolvable, Hashable, PrimitiveEncodable {
+public struct Reference<M: ReadableModel>: Resolvable, Hashable, PrimitiveEncodable, Sendable where M.Identifier: Sendable {
     /// The referenced id
     public let reference: M.Identifier
     


### PR DESCRIPTION
## Description
Added Sendable conformance to Field and Reference types for improved thread safety and compatibility with concurrent Swift contexts:
- #352

## Motivation and Context
This change ensures compatibility with `Sendable` requirements in Swift's concurrency model, addressing thread-safety concerns for asynchronous use cases. No breaking changes are introduced.  

## How Has This Been Tested?
- Manual testing of affected structures in a concurrent environment to ensure proper `Sendable` behavior.
- Reviewed usage of `Field` and `Reference` types to confirm no adverse impact on existing functionality.

## Checklist:
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.