### PR TITLE
Add batchSize() method to AggregateBuilderPipeline for API consistency [WIP]

### DIFF
--- a/Sources/MongoKitten/Aggregate.swift
+++ b/Sources/MongoKitten/Aggregate.swift
@@ -80,7 +80,7 @@ public struct AggregateBuilderPipeline: CountableCursor {
     internal var _allowDiskUse: Bool?
     internal var _collation: Collation?
     internal var _readConcern: ReadConcern?
-    internal var _batchSize: Int32?
+    internal var _batchSize: Int?
     
     /// Enables disk usage for large datasets that exceed memory limits.
     ///
@@ -171,9 +171,8 @@ public struct AggregateBuilderPipeline: CountableCursor {
 
     /// Sets the batch size for cursor operations
     public func batchSize(_ batchSize: Int) -> AggregateBuilderPipeline {
-        precondition(batchSize > 0, "Batch size must be positive")
         var pipeline = self
-        pipeline._batchSize = Int32(batchSize)
+        pipeline._batchSize = batchSize
         return pipeline
     }
     

--- a/Sources/MongoKitten/Aggregate.swift
+++ b/Sources/MongoKitten/Aggregate.swift
@@ -80,6 +80,7 @@ public struct AggregateBuilderPipeline: CountableCursor {
     internal var _allowDiskUse: Bool?
     internal var _collation: Collation?
     internal var _readConcern: ReadConcern?
+    internal var _batchSize: Int32?
     
     /// Enables disk usage for large datasets that exceed memory limits.
     ///
@@ -167,6 +168,14 @@ public struct AggregateBuilderPipeline: CountableCursor {
         pipeline._readConcern = readConcern
         return pipeline
     }
+
+    /// Sets the batch size for cursor operations
+    public func batchSize(_ batchSize: Int) -> AggregateBuilderPipeline {
+        precondition(batchSize > 0, "Batch size must be positive")
+        var pipeline = self
+        pipeline._batchSize = Int32(batchSize)
+        return pipeline
+    }
     
     internal func makeCommand() -> AggregateCommand {
         var documents = [Document]()
@@ -185,6 +194,9 @@ public struct AggregateBuilderPipeline: CountableCursor {
         command.allowDiskUse = _allowDiskUse
         command.collation = _collation
         command.readConcern = _readConcern
+        if let batchSize = _batchSize {
+            command.cursor.batchSize = batchSize
+        }
         
         return command
     }


### PR DESCRIPTION
## Summary
Adds `.batchSize()` method to `AggregateBuilderPipeline` to provide API consistency with `FindQueryBuilder`.

## Motivation and Context
Currently, `FindQueryBuilder` has a `.batchSize()` method that controls initial batch size, but `AggregateBuilderPipeline` lacks this functionality. This creates inconsistent pagination behavior where find queries can set consistent page sizes from the first batch, while aggregations always use MongoDB's default initial batch size (~101 docs).

## Solution
- Add `_batchSize: Int?` property to store batch size
- Add `batchSize(_ batchSize: Int)` method following existing API patterns
- Update `makeCommand()` to set `command.cursor.batchSize`

## Changes
- `Sources/MongoKitten/Aggregate.swift`: Add batchSize functionality

## Usage
```swift
let pipeline = collection.buildAggregate {
    Match(where: "status" == "active")
}
.batchSize(1000) // Now available!
.allowDiskUse()

let cursor = try await pipeline.execute()
let firstBatch = try await cursor.nextBatch() // First batch now respects batchSize
```
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.