### PR TITLE
Call `discardReadBytes` instead of `slice`, which cleans up memory

### DIFF
--- a/Sources/MongoKitten/GridFS/GridFSFileWriter.swift
+++ b/Sources/MongoKitten/GridFS/GridFSFileWriter.swift
@@ -218,6 +218,6 @@ public final class GridFSFileWriter {
         }
         
         // Trim the buffer to the current size
-        buffer = buffer.slice()
+        buffer.discardReadBytes()
     }
 }


### PR DESCRIPTION
Fixes #359 